### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,6 @@
 {
 	"name"			: "Text::Diff::Sift4",
+	"license" : "Artistic-2.0",
 	"version"		: "1.3.0",
 	"description"	: "A quick string distance algorithm",
 	"authors"		: ["Daniel Green"],


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license